### PR TITLE
Fix multibyte path hash handling in MishMesh

### DIFF
--- a/examples/companion_radio/MyMesh.cpp
+++ b/examples/companion_radio/MyMesh.cpp
@@ -480,11 +480,10 @@ void MyMesh::queueMessage(const ContactInfo &from, uint8_t txt_type, mesh::Packe
   // [mishmesh]
   // Same allowlist as should_display: never store raw CLI_DATA frames as DMs.
   if (_mm_store && (txt_type == TXT_TYPE_PLAIN || txt_type == TXT_TYPE_SIGNED_PLAIN)) {
-    uint8_t hops = 0;
+    uint8_t pathLen = 0;
     const uint8_t* pathPtr = nullptr;
     if (pkt && pkt->isRouteFlood()) {
-      hops = pkt->getPathHashCount();
-      if (hops > mishmesh::MAX_PATH) hops = mishmesh::MAX_PATH;
+      pathLen = (uint8_t)pkt->path_len;
       pathPtr = pkt->path;
     }
     mishmesh::ConvoKey k = mishmesh::directKey(from.id.pub_key);
@@ -507,11 +506,11 @@ void MyMesh::queueMessage(const ContactInfo &from, uint8_t txt_type, mesh::Packe
       if (m > (int)mishmesh::MAX_TEXT) m = mishmesh::MAX_TEXT;
       _mm_store->appendInbound(k, roombuf, (uint16_t)m, sender_timestamp,
                                 getRTCClock()->getCurrentTime(),
-                                pkt ? pkt->_snr : 0, pathPtr, hops);
+                                pkt ? pkt->_snr : 0, pathPtr, pathLen);
     } else {
       _mm_store->appendInbound(k, text, (uint16_t)strlen(text), sender_timestamp,
                                 getRTCClock()->getCurrentTime(),
-                                pkt ? pkt->_snr : 0, pathPtr, hops);
+                                pkt ? pkt->_snr : 0, pathPtr, pathLen);
     }
   }
   // [/mishmesh]
@@ -641,17 +640,16 @@ void MyMesh::onChannelMessageRecv(const mesh::GroupChannel &channel, mesh::Packe
 #endif
   // [mishmesh]
   if (_mm_store) {
-    uint8_t hops = 0;
+    uint8_t pathLen = 0;
     const uint8_t* pathPtr = nullptr;
     if (pkt && pkt->isRouteFlood()) {
-      hops = pkt->getPathHashCount();
-      if (hops > mishmesh::MAX_PATH) hops = mishmesh::MAX_PATH;
+      pathLen = (uint8_t)pkt->path_len;
       pathPtr = pkt->path;
     }
     mishmesh::ConvoKey k = mishmesh::channelKey(channel_idx);
     _mm_store->appendInbound(k, text, (uint16_t)strlen(text), timestamp,
                               getRTCClock()->getCurrentTime(),
-                              pkt ? pkt->_snr : 0, pathPtr, hops);
+                              pkt ? pkt->_snr : 0, pathPtr, pathLen);
   }
   // [/mishmesh]
 }
@@ -2893,9 +2891,8 @@ void MyMesh::logRx(mesh::Packet* pkt, int len, float score) {
     if (dl < 5) continue;  // need at minimum: 4-byte ts + type byte
     uint32_t ts;
     memcpy(&ts, data, 4);
-    uint8_t hops = pkt->getPathHashCount();
-    if (hops > mishmesh::MAX_PATH) hops = mishmesh::MAX_PATH;
-    _mm_store->addRepeat(mishmesh::channelKey(ch), ts, pkt->_snr, pkt->path, hops);
+    _mm_store->addRepeat(mishmesh::channelKey(ch), ts, pkt->_snr, pkt->path,
+                         (uint8_t)pkt->path_len);
     break;  // first matching channel wins
   }
 #endif

--- a/examples/companion_radio/ui-mishmesh/UITask.cpp
+++ b/examples/companion_radio/ui-mishmesh/UITask.cpp
@@ -500,7 +500,7 @@ void UITask::fillView(const ContactInfo& c, mishmesh::ContactView& out) {
   out.type = c.type;
   out.isFavourite = (c.flags & 0x01) != 0;
   out.hasPath = c.out_path_len != OUT_PATH_UNKNOWN;
-  out.hops = out.hasPath ? c.out_path_len : 0;
+  out.hops = out.hasPath ? (c.out_path_len & 63) : 0;
   out.lastAdvert = c.last_advert_timestamp;
   out.pubKey = c.id.pub_key;
   out.hasLocation = (c.gps_lat != 0 || c.gps_lon != 0);
@@ -939,14 +939,14 @@ bool UITask::MsgSvc::getRepeat(const mishmesh::ConvoKey& k, int m, int r, mishme
   return true;
 }
 
-bool UITask::MsgSvc::resolveHop(uint8_t hashByte, const char*& name, uint8_t& knownCount) const {
+bool UITask::MsgSvc::resolveHop(const uint8_t* hash, uint8_t hashSize, const char*& name, uint8_t& knownCount) const {
   static char buf[34]; knownCount = 0; name = "";
   int n = the_mesh.getNumContacts();
   bool hasFirst = false;
   ContactInfo ci;
   for (int i = 0; i < n; i++) {
     if (!the_mesh.getContactByIdx(i, ci)) continue;
-    if (ci.id.pub_key[0] == hashByte) {
+    if (memcmp(ci.id.pub_key, hash, hashSize) == 0) {
       if (!hasFirst) { snprintf(buf, sizeof(buf), "%s", ci.name); hasFirst = true; }
       knownCount++;
     }
@@ -958,7 +958,7 @@ bool UITask::MsgSvc::resolveHop(uint8_t hashByte, const char*& name, uint8_t& kn
     int d = the_mesh.uiDiscoveryCount();
     for (int i = 0; i < d; i++) {
       if (!the_mesh.uiGetDiscovery(i, ci)) continue;
-      if (ci.id.pub_key[0] == hashByte) {
+      if (memcmp(ci.id.pub_key, hash, hashSize) == 0) {
         snprintf(buf, sizeof(buf), "%s", ci.name); hasFirst = true; break;
       }
     }

--- a/examples/companion_radio/ui-mishmesh/UITask.h
+++ b/examples/companion_radio/ui-mishmesh/UITask.h
@@ -84,7 +84,7 @@ class UITask : public AbstractUITask, public mishmesh::AppServices, public mishm
     void clearActiveConvo() override;
     int  repeatCount(const mishmesh::ConvoKey& k, int m) const override;
     bool getRepeat(const mishmesh::ConvoKey& k, int m, int r, mishmesh::RepeatView& out) const override;
-    bool resolveHop(uint8_t hashByte, const char*& name, uint8_t& knownCount) const override;
+    bool resolveHop(const uint8_t* hash, uint8_t hashSize, const char*& name, uint8_t& knownCount) const override;
     void deleteMessage(const mishmesh::ConvoKey& k, int i) override;
     void clearConvo(const mishmesh::ConvoKey& k) override;
     void deleteConvo(const mishmesh::ConvoKey& k) override;

--- a/mishmesh/applets/MessagePathApplet.cpp
+++ b/mishmesh/applets/MessagePathApplet.cpp
@@ -12,12 +12,15 @@ void MessagePathApplet::onStart(AppletContext& ctx) {
   rebuild();
 }
 
-void MessagePathApplet::hopLabel(uint8_t b, char* out, size_t cap) const {
+void MessagePathApplet::hopLabel(const uint8_t* hash, uint8_t size, char* out, size_t cap) const {
   const char* name = ""; uint8_t kc = 0;
-  if (_svc && _svc->resolveHop(b, name, kc) && name && name[0])
+  if (_svc && _svc->resolveHop(hash, size, name, kc) && name && name[0]) {
     snprintf(out, cap, "%s", name);
-  else
-    snprintf(out, cap, "%02X", b);
+  } else {
+    size_t used = 0;
+    for (uint8_t i = 0; i < size && used + 2 < cap; i++)
+      used += (size_t)snprintf(out + used, cap - used, "%02X", hash[i]);
+  }
 }
 
 void MessagePathApplet::rebuild() {
@@ -46,8 +49,9 @@ void MessagePathApplet::rebuild() {
       // The repeater we actually heard this echo from is the LAST hop; the path
       // accumulates origin-first, so path[0] is always our nearest repeater and
       // uninformative here.
-      if (rv.pathLen > 0) {
-        char lbl[34]; hopLabel(rv.path[rv.pathLen - 1], lbl, sizeof(lbl));
+      if (rv.hops > 0) {
+        uint8_t size = pathHashSize(rv.pathLen);
+        char lbl[34]; hopLabel(rv.path + (rv.hops - 1) * size, size, lbl, sizeof(lbl));
         _text.addf("  %s", lbl);
       } else {
         _text.addLine("  (direct)");
@@ -56,16 +60,17 @@ void MessagePathApplet::rebuild() {
     }
   } else {
     // inbound (or outbound DM with no path): the flood relay chain
-    if (m.pathLen == 0)   snprintf(_title, sizeof(_title), "Direct");
+    if (m.hops == 0)      snprintf(_title, sizeof(_title), "Direct");
     else if (m.hops == 1) snprintf(_title, sizeof(_title), "Path: 1 hop");
     else                  snprintf(_title, sizeof(_title), "Path: %u hops", (unsigned)m.hops);
     _bar.setTitle(_title);
-    for (int h = 0; h < m.pathLen; h++) {
-      char lbl[20]; hopLabel(m.path[h], lbl, sizeof(lbl));
+    uint8_t size = pathHashSize(m.pathLen);
+    for (int h = 0; h < m.hops; h++) {
+      char lbl[20]; hopLabel(m.path + h * size, size, lbl, sizeof(lbl));
       _text.addf("%d  %s", h + 1, lbl);
       _rows++;
     }
-    if (m.pathLen == 0) _text.addLine("Direct (no path)");
+    if (m.hops == 0) _text.addLine("Direct (no path)");
   }
 }
 

--- a/mishmesh/applets/MessagePathApplet.h
+++ b/mishmesh/applets/MessagePathApplet.h
@@ -19,7 +19,7 @@ public:
   const char* lineForTest(int i) const { return _text.lineForTest(i); }
 private:
   void rebuild();
-  void hopLabel(uint8_t b, char* out, size_t cap) const;   // name if known, else %02X
+  void hopLabel(const uint8_t* hash, uint8_t size, char* out, size_t cap) const;
   MessagesService* _svc = nullptr;
   AppServices*     _app = nullptr;
   ConvoKey         _key{};

--- a/mishmesh/core/MessageStore.cpp
+++ b/mishmesh/core/MessageStore.cpp
@@ -261,10 +261,11 @@ void MessageStore::appendInbound(const ConvoKey& key, const char* text, uint16_t
                                   uint32_t senderTime, uint32_t recvTime,
                                   int8_t snrx4, const uint8_t* path, uint8_t pathLen) {
   if (textLen > MAX_TEXT) textLen = MAX_TEXT;
-  if (pathLen > MAX_PATH) pathLen = MAX_PATH;
+  pathLen = clampPathLen(pathLen);
+  uint8_t pathBytes = pathByteLen(pathLen);
 
   if (_backend) {
-    uint32_t recLen = (uint32_t)(codec::REC_HDR + textLen + 2 + pathLen);
+    uint32_t recLen = (uint32_t)(codec::REC_HDR + textLen + 2 + pathBytes);
     if (!ensureSpace(key, recLen)) return;
   }
 
@@ -272,12 +273,12 @@ void MessageStore::appendInbound(const ConvoKey& key, const char* text, uint16_t
   if (_backend) rotateIfNeeded(key, c);
 
   if (_backend) {
-    uint8_t trailer[2 + MAX_PATH];
+    uint8_t trailer[2 + MAX_PATH_BYTES];
     trailer[0] = (uint8_t)snrx4;
     trailer[1] = pathLen;
-    if (pathLen) memcpy(trailer + 2, path, pathLen);
+    if (pathBytes && path) memcpy(trailer + 2, path, pathBytes);
     int n = codec::writeRecord(_recBuf, KIND_INBOUND, key, text, textLen,
-                               senderTime, recvTime, trailer, (uint8_t)(2 + pathLen));
+                               senderTime, recvTime, trailer, (uint8_t)(2 + pathBytes));
     char name[15]; codec::keyToName(key, name);
     if (!_backend->append(name, _recBuf, (uint32_t)n)) return;
     c.logBytes += (uint32_t)n;
@@ -427,11 +428,12 @@ void MessageStore::addRepeat(const ConvoKey& key, uint32_t senderTime,
                               int8_t snrx4, const uint8_t* path, uint8_t pathLen) {
   Tracked* t = findTracked(key, senderTime);
   if (!t || t->kind != KIND_OUT_CHAN) return;
-  if (pathLen > MAX_PATH) pathLen = MAX_PATH;
+  pathLen = clampPathLen(pathLen);
+  uint8_t pathBytes = pathByteLen(pathLen);
   if (t->rptCount < MAX_REPEATS) {
     RepeatRec& rr = t->repeats[t->rptCount];
-    rr.snrx4 = snrx4; rr.pathLen = pathLen; rr.hops = pathLen;
-    if (pathLen && path) memcpy(t->rptStore[t->rptCount], path, pathLen);
+    rr.snrx4 = snrx4; rr.pathLen = pathLen; rr.hops = pathHopCount(pathLen);
+    if (pathBytes && path) memcpy(t->rptStore[t->rptCount], path, pathBytes);
     rr.path = t->rptStore[t->rptCount];
     t->rptCount++;
   }
@@ -478,7 +480,7 @@ void MessageStore::decodeRecord(const uint8_t* r, const ConvoKey& key, MsgRecord
   out.status = ST_PENDING; out.tripTimeMs = 0; out.heardCount = 0;
   const uint8_t* t = r + codec::REC_HDR + out.textLen;
   if (out.kind == KIND_INBOUND) {
-    out.snrx4 = (int8_t)t[0]; out.pathLen = t[1]; out.hops = t[1];
+    out.snrx4 = (int8_t)t[0]; out.pathLen = t[1]; out.hops = pathHopCount(t[1]);
     out.path = t + 2;
   } else if (out.kind == KIND_OUT_DM) {
     out.status = t[0]; memcpy(&out.tripTimeMs, t + 1, 2);

--- a/mishmesh/core/MessageStore.h
+++ b/mishmesh/core/MessageStore.h
@@ -98,7 +98,7 @@ private:
   mutable uint8_t _recBuf[codec::MAX_REC]; // scratch for single-record reads (paging)
   // Word-aligned: LittleFS programs/reads this blob directly from here on a large
   // single transfer, and the nRF52840 QSPI DMA rejects a non-word-aligned RAM source.
-  // Without alignas, _recBuf[187] leaves _idxBuf on an odd offset and every index
+  // Without alignas, the odd-sized _recBuf leaves _idxBuf unaligned and every index
   // write silently fails (wrote=0) - the on-device unread-count persistence bug.
   alignas(uint32_t) uint8_t _idxBuf[4096];   // serialised ConvoIndex (MIDX blob, ~3911 bytes max)
 
@@ -109,7 +109,7 @@ private:
     uint8_t  kind;
     uint32_t expectedAck;
     RepeatRec repeats[MAX_REPEATS];
-    uint8_t  rptStore[MAX_REPEATS][MAX_PATH];
+    uint8_t  rptStore[MAX_REPEATS][MAX_PATH_BYTES];
     uint8_t  rptCount;
   };
   Tracked _tracked[MAX_TRACKED];

--- a/mishmesh/core/MessagesService.h
+++ b/mishmesh/core/MessagesService.h
@@ -51,13 +51,13 @@ struct MessageView {
   uint8_t     retryAttempt; // outbound DM still pending: current auto-retry number (0 = none)
   int8_t      snrx4;
   uint8_t     hops;
-  const uint8_t* path; uint8_t pathLen;
+  const uint8_t* path; uint8_t pathLen; // MeshCore encoded path length
 };
 struct RepeatView {
   uint8_t        hops;
   int8_t         snrx4;
-  const uint8_t* path;     // hop hash-bytes; resolve via resolveHop()
-  uint8_t        pathLen;
+  const uint8_t* path;
+  uint8_t        pathLen;   // MeshCore encoded path length
 };
 
 struct MessagesService {
@@ -80,7 +80,7 @@ struct MessagesService {
   virtual void clearActiveConvo() = 0;
   virtual int  repeatCount(const ConvoKey& k, int msgIdx) const = 0;
   virtual bool getRepeat(const ConvoKey& k, int msgIdx, int r, RepeatView& out) const = 0;
-  virtual bool resolveHop(uint8_t hashByte, const char*& name, uint8_t& knownCount) const = 0;
+  virtual bool resolveHop(const uint8_t* hash, uint8_t hashSize, const char*& name, uint8_t& knownCount) const = 0;
   virtual void deleteMessage(const ConvoKey& k, int i) = 0;
   virtual void clearConvo(const ConvoKey& k) = 0;
   virtual void deleteConvo(const ConvoKey& k) = 0;

--- a/mishmesh/core/MsgCodec.cpp
+++ b/mishmesh/core/MsgCodec.cpp
@@ -11,7 +11,7 @@ uint16_t recTextLen(const uint8_t* r) { return r[16]; }
 int recSize(const uint8_t* r) {
   int n = REC_HDR + recTextLen(r);
   switch (recKind(r)) {
-    case KIND_INBOUND:  n += 2 + r[n + 1]; break;   // snrx4(1)+pathLen(1)+path
+    case KIND_INBOUND:  n += 2 + pathByteLen(r[n + 1]); break; // snrx4+encoded path len+path
     case KIND_OUT_DM:   n += 3; break;               // status(1)+trip(2)
     case KIND_OUT_CHAN: n += 2; break;               // status(1)+heard(1)
   }

--- a/mishmesh/core/MsgCodec.h
+++ b/mishmesh/core/MsgCodec.h
@@ -6,7 +6,7 @@
 namespace mishmesh { namespace codec {
 
 constexpr int REC_HDR = 17;                  // flags+type+id(6)+senderTime(4)+localTime(4)+textLen(1)
-constexpr int MAX_REC = REC_HDR + 160 + 10; // worst case = 187
+constexpr int MAX_REC = REC_HDR + MAX_TEXT + 2 + MAX_PATH_BYTES;
 
 uint8_t  recKind(const uint8_t* r);
 bool     recDead(const uint8_t* r);

--- a/mishmesh/core/MsgTypes.h
+++ b/mishmesh/core/MsgTypes.h
@@ -13,7 +13,19 @@ static const int MAX_CONVOS   = 64;
 static const int PER_CHAT_CAP = 100;
 static const int MAX_TRACKED  = 8;
 static const int MAX_REPEATS  = 8;
-static const int MAX_PATH     = 8;
+static const int MAX_PATH     = 8;   // maximum stored/displayed hops
+static const int MAX_PATH_BYTES = MAX_PATH * 3;
+
+inline uint8_t pathHashSize(uint8_t encodedLen) { return (encodedLen >> 6) + 1; }
+inline uint8_t pathHopCount(uint8_t encodedLen) { return encodedLen & 63; }
+inline uint8_t pathByteLen(uint8_t encodedLen) { return pathHopCount(encodedLen) * pathHashSize(encodedLen); }
+inline uint8_t clampPathLen(uint8_t encodedLen) {
+  uint8_t size = pathHashSize(encodedLen);
+  uint8_t hops = pathHopCount(encodedLen);
+  if (size > 3) return 0;
+  if (hops > MAX_PATH) hops = MAX_PATH;
+  return (uint8_t)(((size - 1) << 6) | hops);
+}
 static const int MAX_TEXT     = 160;
 static const int PREVIEW_LEN  = 40;
 
@@ -38,7 +50,7 @@ struct MsgRecord {
   int8_t         snrx4;
   uint8_t        hops;
   const uint8_t* path;
-  uint8_t        pathLen;
+  uint8_t        pathLen;   // encoded: top bits hash size, low 6 bits hop count
   uint8_t        status;
   uint16_t       tripTimeMs;
   uint8_t        heardCount;
@@ -60,7 +72,7 @@ struct RepeatRec {
   int8_t         snrx4;
   uint8_t        hops;
   const uint8_t* path;
-  uint8_t        pathLen;
+  uint8_t        pathLen;   // encoded: top bits hash size, low 6 bits hop count
 };
 
 } // namespace mishmesh

--- a/test/mocks/FakeMessagesService.h
+++ b/test/mocks/FakeMessagesService.h
@@ -63,8 +63,9 @@ struct FakeMessagesService : mishmesh::MessagesService {
     o.hops = rr.hops; o.snrx4 = rr.snrx4; o.path = rr.path; o.pathLen = rr.pathLen;
     return true;
   }
-  bool resolveHop(uint8_t b, const char*& name, uint8_t& kc) const override {
-    if (b == 0xAA) { name = "Alice"; kc = 1; return true; }   // everything else falls back to hex
+  bool resolveHop(const uint8_t* hash, uint8_t size, const char*& name, uint8_t& kc) const override {
+    if (size == 1 && hash[0] == 0xAA) { name = "Alice"; kc = 1; return true; }
+    if (size == 2 && hash[0] == 0xAA && hash[1] == 0xBB) { name = "Alice2"; kc = 1; return true; }
     name = ""; kc = 0; return false;
   }
   void deleteMessage(const mishmesh::ConvoKey& k, int i) override { store.deleteMessage(k, i); deletes++; }

--- a/test/test_mishmesh_messages/test_messages.cpp
+++ b/test/test_mishmesh_messages/test_messages.cpp
@@ -400,6 +400,24 @@ TEST(MessagePath, InboundResolvesNameElseHex) {
   EXPECT_STREQ("2  5B",    mishmesh::messagePathApplet().lineForTest(1));
 }
 
+TEST(MessagePath, InboundGroupsMultibytePathHashes) {
+  FakeMessagesService svc;
+  auto k = mishmesh::directKey((const uint8_t*)"ALICE!");
+  uint8_t path[4] = {0xAA, 0xBB, 0xCC, 0xDD};
+  svc.store.appendInbound(k, "hi", 2, 1, 1, 0, path, 0x42);
+  FakeDisplayDriver d;
+  mishmesh::AppletContext ctx; ctx.messages = &svc;
+  mishmesh::AppletHost host(&d, ctx);
+  host.setRoot(&mishmesh::messagesApplet());
+  mishmesh::messagePathApplet().setTarget(k, 0);
+  host.push(&mishmesh::messagePathApplet());
+  host.loop(0);
+  EXPECT_STREQ("Path: 2 hops", mishmesh::messagePathApplet().titleForTest());
+  EXPECT_EQ(2, mishmesh::messagePathApplet().rowCountForTest());
+  EXPECT_STREQ("1  Alice2", mishmesh::messagePathApplet().lineForTest(0));
+  EXPECT_STREQ("2  CCDD", mishmesh::messagePathApplet().lineForTest(1));
+}
+
 TEST(MessagePath, InboundDirectHasNoHops) {
   FakeMessagesService svc;
   auto k = mishmesh::directKey((const uint8_t*)"ALICE!");

--- a/test/test_mishmesh_messagestore/test_messagestore.cpp
+++ b/test/test_mishmesh_messagestore/test_messagestore.cpp
@@ -34,6 +34,16 @@ TEST_F(MSFix, InboundCreatesConvoAndMessage) {
   EXPECT_EQ(0x63, r.path[1]);
 }
 
+TEST_F(MSFix, InboundPreservesMultibytePathHashes) {
+  uint8_t path[4] = {0xAA, 0xBB, 0xCC, 0xDD};
+  s.appendInbound(dm("ALICE!"), "hi", 2, 1000, 2000, -32, path, 0x42);
+  MsgRecord r;
+  ASSERT_TRUE(s.getMessage(dm("ALICE!"), 0, r));
+  EXPECT_EQ(0x42, r.pathLen);
+  EXPECT_EQ(2, r.hops);
+  EXPECT_EQ(0, memcmp(path, r.path, 4));
+}
+
 TEST_F(MSFix, RecencySortedNewestFirst) {
   s.appendInbound(dm("ALICE!"), "a", 1, 100, 100, 0, nullptr, 0);
   s.appendInbound(dm("BOBBBB"), "b", 1, 200, 200, 0, nullptr, 0);


### PR DESCRIPTION
## Summary

This patch fixes MishMesh message-path handling for MeshCore packets that use 2-byte or 3-byte path hashes. It preserves the encoded path metadata, stores the complete path, renders each complete hash as one hop, and resolves repeaters using all bytes in the hash.

> **Disclaimer:** This patch was fully written by **ChatGPT 5.6 Sol High**.

## Why this is needed

MeshCore stores both the hash size and hop count in `path_len`:

```cpp
hashSize = (path_len >> 6) + 1;
hopCount = path_len & 63;
```

For example, `0x42` represents two hops with two-byte hashes:

```text
AABB CCDD
```

The previous MishMesh code discarded the hash-size information by calling `getPathHashCount()` and then used that hop count as the number of bytes to store:

```cpp
uint8_t hops = pkt->getPathHashCount();

_mm_store->appendInbound(
    ...,
    pkt->path,
    hops
);
```

`MessageStore` copied exactly that number of bytes:

```cpp
if (pathLen) memcpy(trailer + 2, path, pathLen);
```

For `AABB CCDD`, the hop count is `2`, but the path contains four bytes. Only `AA BB` was therefore retained, while `CC DD` was lost.

The UI also treated every retained byte as an independent hop:

```cpp
for (int h = 0; h < m.pathLen; h++) {
    hopLabel(m.path[h], ...);
}
```

This could render:

```text
1  AA
2  BB
```

instead of:

```text
1  AABB
2  CCDD
```

Repeater resolution had the same assumption and compared only one public-key byte:

```cpp
if (ci.id.pub_key[0] == hashByte) {
```

## Changes made

The patch changes 14 files with 95 insertions and 50 deletions, including regression tests.

### Preserve the encoded path length

Inbound messages and channel repeats now pass the original encoded `pkt->path_len` value instead of passing only the hop count:

```cpp
uint8_t pathLen = 0;
const uint8_t* pathPtr = nullptr;

if (pkt && pkt->isRouteFlood()) {
    pathLen = (uint8_t)pkt->path_len;
    pathPtr = pkt->path;
}

_mm_store->appendInbound(
    ...,
    pathPtr,
    pathLen
);
```

This retains both pieces of information required to interpret the path:

- Upper two bits: hash size minus one.
- Lower six bits: number of hops.

### Centralize path-length decoding

Small helpers were added in `mishmesh/core/MsgTypes.h`:

```cpp
inline uint8_t pathHashSize(uint8_t encodedLen) {
    return (encodedLen >> 6) + 1;
}

inline uint8_t pathHopCount(uint8_t encodedLen) {
    return encodedLen & 63;
}

inline uint8_t pathByteLen(uint8_t encodedLen) {
    return pathHopCount(encodedLen) * pathHashSize(encodedLen);
}
```

`clampPathLen()` limits stored paths to MishMesh's existing eight-hop display limit while preserving the encoded hash size.

### Store the complete byte sequence

`MessageStore` now distinguishes between the encoded path length and the actual number of bytes that must be copied:

```cpp
pathLen = clampPathLen(pathLen);
uint8_t pathBytes = pathByteLen(pathLen);

trailer[1] = pathLen;

if (pathBytes && path) {
    memcpy(trailer + 2, path, pathBytes);
}
```

The maximum path buffer was increased from eight bytes to 24 bytes:

```cpp
static const int MAX_PATH = 8;
static const int MAX_PATH_BYTES = MAX_PATH * 3;
```

This keeps the existing maximum of eight hops while allowing each hop to contain up to three bytes.

The message codec now derives the stored record size from the decoded byte count:

```cpp
case KIND_INBOUND:
    n += 2 + pathByteLen(r[n + 1]);
    break;
```

### Render one complete hash per hop

The path applet now calculates the hash size once and advances by that many bytes for each hop:

```cpp
uint8_t size = pathHashSize(m.pathLen);

for (int h = 0; h < m.hops; h++) {
    char lbl[20];
    hopLabel(m.path + h * size, size, lbl, sizeof(lbl));
    _text.addf("%d  %s", h + 1, lbl);
}
```

Unknown hashes are rendered by joining all bytes belonging to the hop. A two-byte hash is therefore displayed as `AABB`, not as separate `AA` and `BB` hops.

The last-repeater view uses the same stride calculation:

```cpp
hopLabel(
    rv.path + (rv.hops - 1) * size,
    size,
    lbl,
    sizeof(lbl)
);
```

### Resolve contacts using the complete hash

`resolveHop()` now receives a pointer and hash size:

```cpp
bool resolveHop(
    const uint8_t* hash,
    uint8_t hashSize,
    const char*& name,
    uint8_t& knownCount
) const;
```

Contact and discovery entries are matched using all bytes in the path hash:

```cpp
if (memcmp(ci.id.pub_key, hash, hashSize) == 0) {
```

This preserves the previous first-byte behavior for one-byte paths while correctly supporting two-byte and three-byte hashes.

### Correct displayed contact hop counts

Contact paths previously exposed the complete encoded value as the number of hops. For example, `0x42` could be displayed as 66 hops.

The UI now reads only the lower six bits:

```cpp
out.hops = out.hasPath ? (c.out_path_len & 63) : 0;
```

### Add regression coverage

A message-store test verifies that a `0x42` path:

```text
AABB CCDD
```

is retained as four bytes while reporting two hops.

A path-applet test verifies that the same path renders as:

```text
1  Known repeater
2  CCDD
```

rather than splitting or truncating the hashes.

## Why this approach

The patch keeps the fix small by using MeshCore's existing path encoding throughout MishMesh rather than adding separate `hashSize`, `hopCount`, and byte-length fields to every message structure.

This approach was selected because:

1. **It keeps one source of truth.** The original `path_len` already contains everything needed to decode the path.
2. **It minimizes structural changes.** Existing message and repeat records still store one path-length byte.
3. **It preserves one-byte compatibility.** For one-byte hashes, encoded path lengths from `0x00` through `0x3F` are identical to the old hop-count values, so existing one-byte records remain readable.
4. **It avoids repeated bit manipulation.** Shared helpers define the decoding rules once and are used by storage, record sizing, and rendering.
5. **It retains the existing eight-hop limit.** Only the backing byte capacity changes from 8 to 24 bytes.
6. **It makes resolution match the wire format.** Repeater lookup compares exactly the one, two, or three bytes represented by each path entry.

Previously stored multibyte paths may already have been truncated and cannot be reconstructed, but new messages are now stored and displayed correctly.

Fixes #8