### PR TITLE
Add persistent screen brightness control to MishMesh

### DIFF
--- a/examples/companion_radio/ui-mishmesh/UITask.cpp
+++ b/examples/companion_radio/ui-mishmesh/UITask.cpp
@@ -60,8 +60,19 @@ static void platformHeap(uint32_t& freeBytes, uint32_t& totalBytes) {
 #endif
 }
 
+static uint8_t brightnessValue(uint8_t idx) {
+  static const uint8_t LEVELS[] = { 16, 64, 128, 192, 255 };
+  return LEVELS[idx < 5 ? idx : 2];
+}
+
 uint32_t UITask::epochSeconds() const {
   return rtc_clock.getCurrentTime();
+}
+
+void UITask::setScreenBrightnessIndex(uint8_t idx) {
+  _screenBrightness = idx < 5 ? idx : 2;
+  _theStorage.save("brgt", &_screenBrightness, 1);
+  if (_display) _display->setBrightness(brightnessValue(_screenBrightness));
 }
 
 // [mishmesh]
@@ -188,6 +199,10 @@ void UITask::begin(DisplayDriver* display, SensorManager* sensors, NodePrefs* no
   _retryGlue.store = &_msgStore;      // auto-retry acts on the same store
   _theStorage.ds = the_mesh.getStore();
   _msgSvc.storage = &_theStorage;     // per-chat region persistence
+  uint8_t savedBrightness = 2;
+  if (_theStorage.load("brgt", &savedBrightness, 1) == 1 && savedBrightness < 5)
+    _screenBrightness = savedBrightness;
+  _display->setBrightness(brightnessValue(_screenBrightness));
   the_mesh.uiSetMessageStore(&_msgStore);
   // Surface joined channels (e.g. the default Public channel) as chats even
   // before any message arrives - the store is otherwise only fed on message capture.

--- a/examples/companion_radio/ui-mishmesh/UITask.cpp
+++ b/examples/companion_radio/ui-mishmesh/UITask.cpp
@@ -62,7 +62,7 @@ static void platformHeap(uint32_t& freeBytes, uint32_t& totalBytes) {
 
 static uint8_t brightnessValue(uint8_t idx) {
   static const uint8_t LEVELS[] = { 16, 64, 128, 192, 255 };
-  return LEVELS[idx < 5 ? idx : 2];
+  return LEVELS[idx < 5 ? idx : 4];
 }
 
 uint32_t UITask::epochSeconds() const {
@@ -70,7 +70,7 @@ uint32_t UITask::epochSeconds() const {
 }
 
 void UITask::setScreenBrightnessIndex(uint8_t idx) {
-  _screenBrightness = idx < 5 ? idx : 2;
+  _screenBrightness = idx < 5 ? idx : 4;
   _theStorage.save("brgt", &_screenBrightness, 1);
   if (_display) _display->setBrightness(brightnessValue(_screenBrightness));
 }
@@ -199,7 +199,7 @@ void UITask::begin(DisplayDriver* display, SensorManager* sensors, NodePrefs* no
   _retryGlue.store = &_msgStore;      // auto-retry acts on the same store
   _theStorage.ds = the_mesh.getStore();
   _msgSvc.storage = &_theStorage;     // per-chat region persistence
-  uint8_t savedBrightness = 2;
+  uint8_t savedBrightness = 4;
   if (_theStorage.load("brgt", &savedBrightness, 1) == 1 && savedBrightness < 5)
     _screenBrightness = savedBrightness;
   _display->setBrightness(brightnessValue(_screenBrightness));

--- a/examples/companion_radio/ui-mishmesh/UITask.h
+++ b/examples/companion_radio/ui-mishmesh/UITask.h
@@ -59,6 +59,7 @@ class UITask : public AbstractUITask, public mishmesh::AppServices, public mishm
   uint32_t _msgDirtySeq = 0;
   uint32_t _msgFlushAt  = 0;
   uint32_t _msgDirtySince = 0;   // when the store first went dirty; caps flush deferral
+  uint8_t _screenBrightness = 2; // 0..4; default Medium
 
   struct MsgSvc : public mishmesh::MessagesService {
     mishmesh::MessageStore* store = nullptr;
@@ -363,6 +364,9 @@ public:
     the_mesh.savePrefs();
     if (_host) _host->setAutoOffMillis(mishmesh::screenSleepMillis(idx));   // live
   }
+  bool screenBrightnessSupported() const override { return _display && _display->supportsBrightness(); }
+  uint8_t screenBrightnessIndex() const override { return _screenBrightness; }
+  void setScreenBrightnessIndex(uint8_t idx) override;
   bool setNodeName(const char* name) override {
     if (!mishmesh::isValidNodeName(name)) return false;
     NodePrefs* p = the_mesh.getNodePrefs();

--- a/examples/companion_radio/ui-mishmesh/UITask.h
+++ b/examples/companion_radio/ui-mishmesh/UITask.h
@@ -59,7 +59,7 @@ class UITask : public AbstractUITask, public mishmesh::AppServices, public mishm
   uint32_t _msgDirtySeq = 0;
   uint32_t _msgFlushAt  = 0;
   uint32_t _msgDirtySince = 0;   // when the store first went dirty; caps flush deferral
-  uint8_t _screenBrightness = 2; // 0..4; default Medium
+  uint8_t _screenBrightness = 4; // 0..4; default Maximum (library default)
 
   struct MsgSvc : public mishmesh::MessagesService {
     mishmesh::MessageStore* store = nullptr;

--- a/mishmesh/applets/settings/HomeSettingsPanel.cpp
+++ b/mishmesh/applets/settings/HomeSettingsPanel.cpp
@@ -59,7 +59,7 @@ static void sleepStepLabel(int idx, char* out, uint16_t cap) {
 
 static void brightnessStepLabel(int idx, char* out, uint16_t cap) {
   static const char* const LABELS[] = { "Minimum", "Low", "Medium", "High", "Maximum" };
-  snprintf(out, cap, "%s", LABELS[idx < 5 ? idx : 2]);
+  snprintf(out, cap, "%s", LABELS[idx < 5 ? idx : 4]);
 }
 
 const char* HomeSettingsPanel::Model::label(int i) const {

--- a/mishmesh/applets/settings/HomeSettingsPanel.cpp
+++ b/mishmesh/applets/settings/HomeSettingsPanel.cpp
@@ -57,9 +57,14 @@ static void sleepStepLabel(int idx, char* out, uint16_t cap) {
   snprintf(out, cap, "%s", screenSleepLabel(idx));
 }
 
+static void brightnessStepLabel(int idx, char* out, uint16_t cap) {
+  static const char* const LABELS[] = { "Minimum", "Low", "Medium", "High", "Maximum" };
+  snprintf(out, cap, "%s", LABELS[idx < 5 ? idx : 2]);
+}
+
 const char* HomeSettingsPanel::Model::label(int i) const {
   static const char* const LABELS[ROW_COUNT] = {
-    "Battery percent", "Screen sleep", "Left shortcut", "Right shortcut" };
+    "Battery percent", "Screen sleep", "Left shortcut", "Right shortcut", "Screen brightness" };
   return (i >= 0 && i < ROW_COUNT) ? LABELS[i] : "";
 }
 
@@ -71,6 +76,11 @@ const char* HomeSettingsPanel::Model::value(int i) const {
   if (i == ScreenSleep) return app ? screenSleepLabel(app->screenSleepIndex()) : "";
   if (i == LeftAction)  return uiPrefs().quickActionLabel(UiPrefs::SLOT_LEFT);
   if (i == RightAction) return uiPrefs().quickActionLabel(UiPrefs::SLOT_RIGHT);
+  if (i == ScreenBrightness && app) {
+    static char label[12];
+    brightnessStepLabel(app->screenBrightnessIndex(), label, sizeof(label));
+    return label;
+  }
   return nullptr;
 }
 
@@ -81,22 +91,28 @@ void HomeSettingsPanel::begin(AppletContext& ctx) {
   _list.setModel(&_model);
   _list.resetSelection();   // singleton reuse: setModel skips reset on same-ptr rebind
   _editingSleep = false;
+  _editingBrightness = false;
 }
 
 int HomeSettingsPanel::renderBody(Canvas& c, int x, int y, int w, int h) {
   _list.draw(c, x, y, w, h);
-  if (_editingSleep) { _stepper.draw(c, 0, 0, c.width(), c.height()); return 100; }
+  if (_editingSleep || _editingBrightness) {
+    _stepper.draw(c, 0, 0, c.width(), c.height());
+    return 100;
+  }
   return _list.needsAnimation() ? ListMenu::TICK_MS : 500;
 }
 
 bool HomeSettingsPanel::onInput(InputEvent ev) {
-  if (_editingSleep) {
+  if (_editingSleep || _editingBrightness) {
     if (_stepper.onInput(ev)) {
       StepperResult r = _stepper.result();
       if (r != StepperResult::None) {
-        if (r == StepperResult::Confirmed && _model.app)
-          _model.app->setScreenSleepIndex((uint8_t)_stepper.value());
-        _editingSleep = false;
+        if (r == StepperResult::Confirmed && _model.app) {
+          if (_editingSleep) _model.app->setScreenSleepIndex((uint8_t)_stepper.value());
+          else _model.app->setScreenBrightnessIndex((uint8_t)_stepper.value());
+        }
+        _editingSleep = _editingBrightness = false;
         _stepper.reset();
       }
     }
@@ -113,6 +129,12 @@ bool HomeSettingsPanel::onInput(InputEvent ev) {
         _stepper.configure("Screen sleep", _model.app->screenSleepIndex(),
                            0, SCREEN_SLEEP_COUNT - 1, sleepStepLabel);
         _editingSleep = true;
+      }
+    } else if (i == Model::ScreenBrightness) {
+      if (_model.app) {
+        _stepper.configure("Screen brightness", _model.app->screenBrightnessIndex(),
+                           0, 4, brightnessStepLabel);
+        _editingBrightness = true;
       }
     } else if (_host) {
       static SettingsDetailApplet detail;   // one level below the shared detail

--- a/mishmesh/applets/settings/HomeSettingsPanel.h
+++ b/mishmesh/applets/settings/HomeSettingsPanel.h
@@ -45,13 +45,13 @@ public:
   void begin(AppletContext& ctx) override;
   int  renderBody(Canvas& c, int x, int y, int w, int h) override;
   bool onInput(InputEvent ev) override;
-  bool modalActive() const override { return _editingSleep; }
+  bool modalActive() const override { return _editingSleep || _editingBrightness; }
 
 private:
   struct Model : ListModel {
     AppServices* app = nullptr;
-    enum Row : int { BattPercent, ScreenSleep, LeftAction, RightAction, ROW_COUNT };
-    int count() const override { return ROW_COUNT; }
+    enum Row : int { BattPercent, ScreenSleep, LeftAction, RightAction, ScreenBrightness, ROW_COUNT };
+    int count() const override { return app && app->screenBrightnessSupported() ? ROW_COUNT : ROW_COUNT - 1; }
     const char* label(int i) const override;
     bool isToggle(int i) const override { return i == BattPercent; }
     bool toggleState(int i) const override;
@@ -60,8 +60,9 @@ private:
 
   AppletHost* _host = nullptr;
   ListMenu _list;
-  StepperDialog _stepper;          // in-panel modal for the sleep picker
+  StepperDialog _stepper;
   bool _editingSleep = false;
+  bool _editingBrightness = false;
 };
 
 HomeSettingsPanel& homeSettings();

--- a/mishmesh/core/Applet.h
+++ b/mishmesh/core/Applet.h
@@ -129,6 +129,9 @@ struct AppServices {
   // it to NodePrefs and applies it live to the AppletHost.
   virtual uint8_t screenSleepIndex() const { return 1; }
   virtual void    setScreenSleepIndex(uint8_t) {}
+  virtual bool    screenBrightnessSupported() const { return false; }
+  virtual uint8_t screenBrightnessIndex() const { return 2; }
+  virtual void    setScreenBrightnessIndex(uint8_t) {}
   // Set + persist the device (advert) name. Rejects invalid/empty names
   // (isValidNodeName). Returns true if applied. Save only - no advert is sent.
   // Defaults keep the framework companion-agnostic (not settable).

--- a/mishmesh/core/Applet.h
+++ b/mishmesh/core/Applet.h
@@ -130,7 +130,7 @@ struct AppServices {
   virtual uint8_t screenSleepIndex() const { return 1; }
   virtual void    setScreenSleepIndex(uint8_t) {}
   virtual bool    screenBrightnessSupported() const { return false; }
-  virtual uint8_t screenBrightnessIndex() const { return 2; }
+  virtual uint8_t screenBrightnessIndex() const { return 4; }
   virtual void    setScreenBrightnessIndex(uint8_t) {}
   // Set + persist the device (advert) name. Rejects invalid/empty names
   // (isValidNodeName). Returns true if applied. Save only - no advert is sent.

--- a/src/helpers/ui/DisplayDriver.h
+++ b/src/helpers/ui/DisplayDriver.h
@@ -15,6 +15,8 @@ public:
 
   virtual bool isOn() = 0;
   virtual bool isEink() { return false; } // default to non-eink, override in eink drivers
+  virtual bool supportsBrightness() const { return false; }
+  virtual void setBrightness(uint8_t value) { (void)value; }
   virtual void turnOn() = 0;
   virtual void turnOff() = 0;
   virtual void clear() = 0;

--- a/src/helpers/ui/SH1106Display.cpp
+++ b/src/helpers/ui/SH1106Display.cpp
@@ -15,6 +15,12 @@ bool SH1106Display::begin()
   return display.begin(DISPLAY_ADDRESS, true) && i2c_probe(Wire, DISPLAY_ADDRESS);
 }
 
+void SH1106Display::setBrightness(uint8_t value)
+{
+  display.oled_command(SH110X_SETCONTRAST);
+  display.oled_command(value);
+}
+
 void SH1106Display::turnOn()
 {
   display.oled_command(SH110X_DISPLAYON);

--- a/src/helpers/ui/SH1106Display.h
+++ b/src/helpers/ui/SH1106Display.h
@@ -36,6 +36,8 @@ public:
   bool begin();
 
   bool isOn() override { return _isOn; }
+  bool supportsBrightness() const override { return true; }
+  void setBrightness(uint8_t value) override;
   void turnOn() override;
   void turnOff() override;
   void clear() override;

--- a/test/test_mishmesh_homesettings/test_homesettings.cpp
+++ b/test/test_mishmesh_homesettings/test_homesettings.cpp
@@ -29,7 +29,7 @@ void prime() {
 
 struct FakeSleepApp : AppServices {
   uint8_t idx = 1;                                  // 30s
-  uint8_t brightness = 2;                           // Medium
+  uint8_t brightness = 4;                           // Maximum
   const char* nodeName() const override { return "n"; }
   uint16_t batteryMillivolts() const override { return 0; }
   uint32_t epochSeconds() const override { return 0; }
@@ -108,7 +108,7 @@ TEST(HomeSettingsPanel, ScreenBrightnessStepperAppliesSelection) {
   for (int i = 0; i < 4; i++) EXPECT_TRUE(p.onInput(InputEvent::NavDown));
   EXPECT_TRUE(p.onInput(InputEvent::Select));
   EXPECT_TRUE(p.modalActive());
-  EXPECT_TRUE(p.onInput(InputEvent::NavRight));       // Medium -> High
+  EXPECT_TRUE(p.onInput(InputEvent::NavLeft));        // Maximum -> High
   EXPECT_TRUE(p.onInput(InputEvent::Select));
   EXPECT_FALSE(p.modalActive());
   EXPECT_EQ(3, app.brightness);

--- a/test/test_mishmesh_homesettings/test_homesettings.cpp
+++ b/test/test_mishmesh_homesettings/test_homesettings.cpp
@@ -29,11 +29,15 @@ void prime() {
 
 struct FakeSleepApp : AppServices {
   uint8_t idx = 1;                                  // 30s
+  uint8_t brightness = 2;                           // Medium
   const char* nodeName() const override { return "n"; }
   uint16_t batteryMillivolts() const override { return 0; }
   uint32_t epochSeconds() const override { return 0; }
   uint8_t screenSleepIndex() const override { return idx; }
   void setScreenSleepIndex(uint8_t i) override { idx = i; }
+  bool screenBrightnessSupported() const override { return true; }
+  uint8_t screenBrightnessIndex() const override { return brightness; }
+  void setScreenBrightnessIndex(uint8_t i) override { brightness = i; }
 };
 
 }  // namespace
@@ -91,6 +95,23 @@ TEST(HomeSettingsPanel, ScreenSleepStepperAppliesSelection) {
   EXPECT_TRUE(p.onInput(InputEvent::Select));         // confirm
   EXPECT_FALSE(p.modalActive());
   EXPECT_EQ(2, app.idx);
+}
+
+
+TEST(HomeSettingsPanel, ScreenBrightnessStepperAppliesSelection) {
+  prime();
+  FakeSleepApp app;
+  AppletContext ctx; ctx.app = &app;
+  HomeSettingsPanel& p = homeSettings();
+  p.begin(ctx);
+  // Brightness is the fifth row, after the two shortcut rows.
+  for (int i = 0; i < 4; i++) EXPECT_TRUE(p.onInput(InputEvent::NavDown));
+  EXPECT_TRUE(p.onInput(InputEvent::Select));
+  EXPECT_TRUE(p.modalActive());
+  EXPECT_TRUE(p.onInput(InputEvent::NavRight));       // Medium -> High
+  EXPECT_TRUE(p.onInput(InputEvent::Select));
+  EXPECT_FALSE(p.modalActive());
+  EXPECT_EQ(3, app.brightness);
 }
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
## Summary

This patch adds an on-device screen brightness setting to MishMesh. Users can select one of five brightness levels under **Settings → Home**, and the selected value is applied immediately and restored after restarting the device.

> **Disclaimer:** This patch was fully written by **ChatGPT 5.6 Sol High**.

## Why this is needed

MishMesh already allows users to configure related display behavior such as the screen sleep timeout, but there was previously no way to adjust the OLED brightness from the device.

The Wio Tracker L1 uses the `SH1106Display` implementation, which already has direct access to the underlying `Adafruit_SH1106G` display object:

```cpp
class SH1106Display : public DisplayDriver
{
    Adafruit_SH1106G display;
    ...
};
```

The SH1106 controller supports changing display contrast through the `SH110X_SETCONTRAST` command. This contrast value controls the perceived brightness of the OLED.

The Adafruit SH1106 initialization sequence currently sets contrast to its maximum value:

```cpp
SH110X_SETCONTRAST, 0xFF,
```

The new setting therefore defaults to **Maximum (`255`)** so devices without a previously saved brightness value retain the same appearance they had before this feature was added.

## Changes made

### Add an optional display brightness interface

`src/helpers/ui/DisplayDriver.h` now exposes optional brightness support:

```cpp
virtual bool supportsBrightness() const { return false; }
virtual void setBrightness(uint8_t value) { (void)value; }
```

The default implementation reports that brightness is unsupported and performs no action.

This keeps the base display abstraction compatible with displays that cannot adjust brightness, such as future e-ink targets, without requiring every display driver to implement empty methods.

### Implement brightness control for SH1106 displays

`src/helpers/ui/SH1106Display.h` advertises brightness support:

```cpp
bool supportsBrightness() const override { return true; }
void setBrightness(uint8_t value) override;
```

`src/helpers/ui/SH1106Display.cpp` applies the value using the controller's native contrast command:

```cpp
void SH1106Display::setBrightness(uint8_t value)
{
    display.oled_command(SH110X_SETCONTRAST);
    display.oled_command(value);
}
```

This keeps hardware-specific commands inside the SH1106 driver rather than exposing `Adafruit_SH1106G` details to MishMesh or `UITask`.

### Expose brightness through `AppServices`

`mishmesh/core/Applet.h` now provides a small interface that settings panels can use:

```cpp
virtual bool screenBrightnessSupported() const { return false; }
virtual uint8_t screenBrightnessIndex() const { return 4; }
virtual void setScreenBrightnessIndex(uint8_t) {}
```

The default index is `4`, representing **Maximum**, to match the display library's existing `0xFF` initialization value.

The default no-op implementations preserve compatibility with tests, other firmware variants, and app services that do not provide display brightness control.

### Add five user-facing brightness levels

`examples/companion_radio/ui-mishmesh/UITask.cpp` maps the five UI choices to SH1106 contrast values:

```cpp
static uint8_t brightnessValue(uint8_t idx) {
    static const uint8_t LEVELS[] = {
        16,
        64,
        128,
        192,
        255
    };

    return LEVELS[idx < 5 ? idx : 4];
}
```

The levels shown to the user are:

```text
Minimum
Low
Medium
High
Maximum
```

A small set of named levels was chosen instead of exposing all 256 contrast values because it keeps the on-device interface simple and avoids presenting hardware-specific numbers to users.

The minimum is intentionally greater than zero so selecting the lowest level does not make the display effectively unreadable.

### Persist and apply the selected level

`UITask` stores the selected index under the MishMesh applet-storage key `brgt`:

```cpp
void UITask::setScreenBrightnessIndex(uint8_t idx) {
    _screenBrightness = idx < 5 ? idx : 4;
    _theStorage.save("brgt", &_screenBrightness, 1);

    if (_display) {
        _display->setBrightness(
            brightnessValue(_screenBrightness)
        );
    }
}
```

The value is applied immediately, so users can see the result without restarting the device.

During startup, the saved value is loaded and applied:

```cpp
uint8_t savedBrightness = 4;

if (_theStorage.load("brgt", &savedBrightness, 1) == 1 &&
    savedBrightness < 5) {
    _screenBrightness = savedBrightness;
}

_display->setBrightness(
    brightnessValue(_screenBrightness)
);
```

Invalid or missing stored values fall back to **Maximum**.

The setting uses the existing `AppletStorage` mechanism instead of adding another field to `NodePrefs`. This keeps the change local to MishMesh and avoids changing the persisted MeshCore preferences structure.

### Add the setting to the Home settings panel

`mishmesh/applets/settings/HomeSettingsPanel.cpp` adds a new row:

```cpp
"Screen brightness"
```

Selecting it opens the existing `StepperDialog`, following the same interaction pattern as the screen sleep setting:

```cpp
_stepper.configure(
    "Screen brightness",
    _model.app->screenBrightnessIndex(),
    0,
    4,
    brightnessStepLabel
);
```

When the user confirms the selection, the panel calls:

```cpp
_model.app->setScreenBrightnessIndex(
    (uint8_t)_stepper.value()
);
```

The existing stepper was reused rather than introducing another picker widget, keeping the implementation and interaction model consistent with other MishMesh settings.

### Hide the setting on unsupported displays

The number of visible Home settings rows is now based on the display capability:

```cpp
int count() const override {
    return app && app->screenBrightnessSupported()
        ? ROW_COUNT
        : ROW_COUNT - 1;
}
```

This prevents the setting from appearing on displays where changing brightness would have no effect.

The capability check is passed through `UITask`:

```cpp
bool screenBrightnessSupported() const override {
    return _display &&
           _display->supportsBrightness();
}
```

### Extend modal-state handling

The Home settings panel now tracks whether either the screen sleep picker or brightness picker is open:

```cpp
bool modalActive() const override {
    return _editingSleep ||
           _editingBrightness;
}
```

Both settings share the existing `StepperDialog`, while separate state flags determine which setting should be updated when the selection is confirmed.

### Add regression coverage

`test/test_mishmesh_homesettings/test_homesettings.cpp` adds brightness support to the fake app service and verifies that:

1. The brightness row can be selected.
2. The stepper opens.
3. Changing from **Maximum** to **High** updates the selected index.
4. The modal closes after confirmation.

The relevant assertion is:

```cpp
EXPECT_EQ(3, app.brightness);
```

This protects the settings-panel interaction and ensures the selected brightness value is passed to `AppServices`.

## Why this approach

This implementation was designed to keep the feature small and isolated:

1. **Hardware-specific behavior stays in the display driver.**  
   MishMesh does not directly call SH1106 or Adafruit APIs.

2. **Unsupported displays remain unaffected.**  
   Brightness support is optional and capability-gated.

3. **The existing settings UI is reused.**  
   The feature uses the same stepper interaction as screen sleep.

4. **No MeshCore preference format changes are required.**  
   The selected level is stored through MishMesh's existing key/value storage.

5. **Existing brightness is preserved by default.**  
   The fallback is `255`, matching the SH1106 library initialization value.

6. **The value is applied live.**  
   Users can immediately see the effect of their selection.

7. **The UI remains simple.**  
   Five descriptive levels are easier to use on a small display than a raw `0–255` value.

Fixes #1
