### PR TITLE
Add mishmesh companion radio envs for GAT562 30S Mesh Kit

### DIFF
--- a/variants/gat562_30s_mesh_kit/GAT56230SMeshKitBoard.cpp
+++ b/variants/gat562_30s_mesh_kit/GAT56230SMeshKitBoard.cpp
@@ -3,6 +3,9 @@
 
 #include "GAT56230SMeshKitBoard.h"
 
+// [mishmesh]
+float mishmeshBatteryCalFactor = 1.0f;
+// [/mishmesh]
 
 #ifdef NRF52_POWER_MANAGEMENT
 // Static configuration for power management

--- a/variants/gat562_30s_mesh_kit/GAT56230SMeshKitBoard.h
+++ b/variants/gat562_30s_mesh_kit/GAT56230SMeshKitBoard.h
@@ -4,6 +4,9 @@
 #include <Arduino.h>
 #include <helpers/NRF52Board.h>
 
+// [mishmesh]
+extern float mishmeshBatteryCalFactor;
+// [/mishmesh]
 
 class GAT56230SMeshKitBoard : public NRF52BoardDCDC {
 protected:
@@ -26,7 +29,7 @@ public:
     }
     raw = raw / BATTERY_SAMPLES;
 
-    return (ADC_MULTIPLIER * raw) / 4096;
+    return (ADC_MULTIPLIER * raw) / 4096 * mishmeshBatteryCalFactor;  // [mishmesh] trim
   }
 
   const char* getManufacturerName() const override {

--- a/variants/gat562_30s_mesh_kit/platformio.ini
+++ b/variants/gat562_30s_mesh_kit/platformio.ini
@@ -117,3 +117,226 @@ lib_deps =
 extends = GAT562_30S_Mesh_Kit
 build_src_filter = ${GAT562_30S_Mesh_Kit.build_src_filter}
   +<../examples/kiss_modem/>
+
+# The GAT562 30S Mesh Kit is a repeater/solar board: no onboard GPS and no
+# Grove/I2C environment sensors (see product page). It inherits the blanket
+# sensor_base flags anyway, pulling in ~44 KB of dead GPS/climate/current/ToF
+# driver code that's pure waste on the flash-tight mishmesh build. Drop all of
+# it via build_unflags, scoped to the mishmesh envs only (other roles keep
+# full support in case a future kit variant does add GPS).
+[gat562_30s_mishmesh_no_sensors]
+build_unflags =
+  -D ENV_INCLUDE_GPS=1
+  -D ENV_INCLUDE_AHTX0=1
+  -D ENV_INCLUDE_BME280=1
+  -D ENV_INCLUDE_BMP280=1
+  -D ENV_INCLUDE_SHTC3=1
+  -D ENV_INCLUDE_SHT4X=1
+  -D ENV_INCLUDE_LPS22HB=1
+  -D ENV_INCLUDE_INA3221=1
+  -D ENV_INCLUDE_INA219=1
+  -D ENV_INCLUDE_INA226=1
+  -D ENV_INCLUDE_INA260=1
+  -D ENV_INCLUDE_MLX90614=1
+  -D ENV_INCLUDE_VL53L0X=1
+  -D ENV_INCLUDE_BME680=1
+  -D ENV_INCLUDE_BMP085=1
+
+[env:GAT562_30S_Mesh_Kit_companion_radio_ble_mishmesh]
+extends = GAT562_30S_Mesh_Kit
+board_build.ldscript = boards/nrf52840_s140_v6_extrafs.ld
+board_upload.maximum_size = 712704
+build_unflags = ${gat562_30s_mishmesh_no_sensors.build_unflags}
+build_flags = ${GAT562_30S_Mesh_Kit.build_flags}
+  -I examples/companion_radio/ui-mishmesh
+  -I .
+  -I mishmesh/text/mcufont
+  -I mishmesh/text/fonts
+  -I mishmesh/vendor/qrcode
+  -I mishmesh/arduboy
+  -I mishmesh/arduboy/arduboy2
+  -I mishmesh/applets/game2048/game
+  -D MAX_CONTACTS=350
+  -D MAX_GROUP_CHANNELS=40
+  -D BLE_PIN_CODE=123456
+  -D OFFLINE_QUEUE_SIZE=256
+  -D DISPLAY_CLASS=SSD1306Display
+  -D ADVERT_NAME='"@@MAC"'
+  -D MISHMESH_FAST_FLUSH_HZ=1000000
+  -D MISHMESH_NORMAL_I2C_HZ=400000
+build_src_filter = ${GAT562_30S_Mesh_Kit.build_src_filter}
+  +<helpers/nrf52/SerialBLEInterface.cpp>
+  +<../examples/companion_radio/*.cpp>
+  +<../examples/companion_radio/ui-mishmesh/*.cpp>
+  +<../mishmesh/core/*.cpp>
+  +<../mishmesh/widgets/*.cpp>
+  +<../mishmesh/applets/*.cpp>
+  +<../mishmesh/applets/settings/*.cpp>
+  +<../mishmesh/text/Fonts.cpp>
+  +<../mishmesh/text/KeyboardLayouts.cpp>
+  +<../mishmesh/text/mcufont/*.c>
+  +<../mishmesh/text/fonts/*.c>
+  ; [mishmesh] optional local-only glyph overlay (gitignored; empty on fresh clones)
+  +<../mishmesh/text/emoji-local/*.c>
+  +<../mishmesh/text/emoji-local/*.cpp>
+  +<../mishmesh/vendor/qrcode/*.c>
+  +<../mishmesh/arduboy/arduboy2/*.cpp>
+  +<../mishmesh/arduboy/ArduboyEeprom.cpp>
+  +<../mishmesh/arduboy/Eeprom.cpp>
+  +<../mishmesh/arduboy/ArduboyRuntime.cpp>
+  +<../mishmesh/applets/game2048/game/*.cpp>
+  +<../mishmesh/applets/game2048/*.cpp>
+  +<../mishmesh/sound/RtttlSource.cpp>
+  +<../mishmesh/sound/ScoreSource.cpp>
+  +<../mishmesh/sound/ToneSequencer.cpp>
+  +<../mishmesh/sound/SoundEngine.cpp>
+  +<../mishmesh/sound/Sounds.cpp>
+  +<../mishmesh/sound/ToneOutput_nrf52.cpp>
+lib_deps = ${GAT562_30S_Mesh_Kit.lib_deps}
+  densaugeo/base64 @ ~1.4.0
+  end2endzone/NonBlockingRTTTL@^1.3.0
+
+[env:GAT562_30S_Mesh_Kit_companion_radio_usb_mishmesh]
+extends = GAT562_30S_Mesh_Kit
+board_build.ldscript = boards/nrf52840_s140_v6_extrafs.ld
+board_upload.maximum_size = 712704
+build_unflags = ${gat562_30s_mishmesh_no_sensors.build_unflags}
+build_flags = ${GAT562_30S_Mesh_Kit.build_flags}
+  -I examples/companion_radio/ui-mishmesh
+  -I .
+  -I mishmesh/text/mcufont
+  -I mishmesh/text/fonts
+  -I mishmesh/vendor/qrcode
+  -I mishmesh/arduboy
+  -I mishmesh/arduboy/arduboy2
+  -I mishmesh/applets/game2048/game
+  -D MAX_CONTACTS=350
+  -D MAX_GROUP_CHANNELS=40
+  -D DISPLAY_CLASS=SSD1306Display
+  -D OFFLINE_QUEUE_SIZE=256
+  -D ENABLE_USB_INTERFACE
+  -D MISHMESH_FAST_FLUSH_HZ=1000000
+  -D MISHMESH_NORMAL_I2C_HZ=400000
+build_src_filter = ${GAT562_30S_Mesh_Kit.build_src_filter}
+  +<../examples/companion_radio/*.cpp>
+  +<../examples/companion_radio/ui-mishmesh/*.cpp>
+  +<../mishmesh/core/*.cpp>
+  +<../mishmesh/widgets/*.cpp>
+  +<../mishmesh/applets/*.cpp>
+  +<../mishmesh/applets/settings/*.cpp>
+  +<../mishmesh/text/Fonts.cpp>
+  +<../mishmesh/text/KeyboardLayouts.cpp>
+  +<../mishmesh/text/mcufont/*.c>
+  +<../mishmesh/text/fonts/*.c>
+  ; [mishmesh] optional local-only glyph overlay (gitignored; empty on fresh clones)
+  +<../mishmesh/text/emoji-local/*.c>
+  +<../mishmesh/text/emoji-local/*.cpp>
+  +<../mishmesh/vendor/qrcode/*.c>
+  +<../mishmesh/arduboy/arduboy2/*.cpp>
+  +<../mishmesh/arduboy/ArduboyEeprom.cpp>
+  +<../mishmesh/arduboy/Eeprom.cpp>
+  +<../mishmesh/arduboy/ArduboyRuntime.cpp>
+  +<../mishmesh/applets/game2048/game/*.cpp>
+  +<../mishmesh/applets/game2048/*.cpp>
+  +<../mishmesh/sound/RtttlSource.cpp>
+  +<../mishmesh/sound/ScoreSource.cpp>
+  +<../mishmesh/sound/ToneSequencer.cpp>
+  +<../mishmesh/sound/SoundEngine.cpp>
+  +<../mishmesh/sound/Sounds.cpp>
+  +<../mishmesh/sound/ToneOutput_nrf52.cpp>
+lib_deps = ${GAT562_30S_Mesh_Kit.lib_deps}
+  densaugeo/base64 @ ~1.4.0
+  end2endzone/NonBlockingRTTTL@^1.3.0
+
+; TEST ENV: same as companion_radio_usb_mishmesh but with the 2048 game
+; (and the arduboy runtime it alone depends on) dropped, to measure the
+; flash/RAM savings from cutting it.
+[env:GAT562_30S_Mesh_Kit_companion_radio_usb_mishmesh_nogames]
+extends = GAT562_30S_Mesh_Kit
+board_build.ldscript = boards/nrf52840_s140_v6_extrafs.ld
+board_upload.maximum_size = 712704
+build_unflags = ${gat562_30s_mishmesh_no_sensors.build_unflags}
+build_flags = ${GAT562_30S_Mesh_Kit.build_flags}
+  -I examples/companion_radio/ui-mishmesh
+  -I .
+  -I mishmesh/text/mcufont
+  -I mishmesh/text/fonts
+  -I mishmesh/vendor/qrcode
+  -D MAX_CONTACTS=350
+  -D MAX_GROUP_CHANNELS=40
+  -D DISPLAY_CLASS=SSD1306Display
+  -D OFFLINE_QUEUE_SIZE=256
+  -D ENABLE_USB_INTERFACE
+  -D MISHMESH_FAST_FLUSH_HZ=1000000
+  -D MISHMESH_NORMAL_I2C_HZ=400000
+build_src_filter = ${GAT562_30S_Mesh_Kit.build_src_filter}
+  +<../examples/companion_radio/*.cpp>
+  +<../examples/companion_radio/ui-mishmesh/*.cpp>
+  +<../mishmesh/core/*.cpp>
+  +<../mishmesh/widgets/*.cpp>
+  +<../mishmesh/applets/*.cpp>
+  +<../mishmesh/applets/settings/*.cpp>
+  +<../mishmesh/text/Fonts.cpp>
+  +<../mishmesh/text/KeyboardLayouts.cpp>
+  +<../mishmesh/text/mcufont/*.c>
+  +<../mishmesh/text/fonts/*.c>
+  ; [mishmesh] optional local-only glyph overlay (gitignored; empty on fresh clones)
+  +<../mishmesh/text/emoji-local/*.c>
+  +<../mishmesh/text/emoji-local/*.cpp>
+  +<../mishmesh/vendor/qrcode/*.c>
+  +<../mishmesh/sound/RtttlSource.cpp>
+  +<../mishmesh/sound/ScoreSource.cpp>
+  +<../mishmesh/sound/ToneSequencer.cpp>
+  +<../mishmesh/sound/SoundEngine.cpp>
+  +<../mishmesh/sound/Sounds.cpp>
+  +<../mishmesh/sound/ToneOutput_nrf52.cpp>
+lib_deps = ${GAT562_30S_Mesh_Kit.lib_deps}
+  densaugeo/base64 @ ~1.4.0
+  end2endzone/NonBlockingRTTTL@^1.3.0
+
+; TEST ENV: same as companion_radio_ble_mishmesh but with the 2048 game
+; (and the arduboy runtime it alone depends on) dropped.
+[env:GAT562_30S_Mesh_Kit_companion_radio_ble_mishmesh_nogames]
+extends = GAT562_30S_Mesh_Kit
+board_build.ldscript = boards/nrf52840_s140_v6_extrafs.ld
+board_upload.maximum_size = 712704
+build_unflags = ${gat562_30s_mishmesh_no_sensors.build_unflags}
+build_flags = ${GAT562_30S_Mesh_Kit.build_flags}
+  -I examples/companion_radio/ui-mishmesh
+  -I .
+  -I mishmesh/text/mcufont
+  -I mishmesh/text/fonts
+  -I mishmesh/vendor/qrcode
+  -D MAX_CONTACTS=350
+  -D MAX_GROUP_CHANNELS=40
+  -D BLE_PIN_CODE=123456
+  -D OFFLINE_QUEUE_SIZE=256
+  -D DISPLAY_CLASS=SSD1306Display
+  -D ADVERT_NAME='"@@MAC"'
+  -D MISHMESH_FAST_FLUSH_HZ=1000000
+  -D MISHMESH_NORMAL_I2C_HZ=400000
+build_src_filter = ${GAT562_30S_Mesh_Kit.build_src_filter}
+  +<helpers/nrf52/SerialBLEInterface.cpp>
+  +<../examples/companion_radio/*.cpp>
+  +<../examples/companion_radio/ui-mishmesh/*.cpp>
+  +<../mishmesh/core/*.cpp>
+  +<../mishmesh/widgets/*.cpp>
+  +<../mishmesh/applets/*.cpp>
+  +<../mishmesh/applets/settings/*.cpp>
+  +<../mishmesh/text/Fonts.cpp>
+  +<../mishmesh/text/KeyboardLayouts.cpp>
+  +<../mishmesh/text/mcufont/*.c>
+  +<../mishmesh/text/fonts/*.c>
+  ; [mishmesh] optional local-only glyph overlay (gitignored; empty on fresh clones)
+  +<../mishmesh/text/emoji-local/*.c>
+  +<../mishmesh/text/emoji-local/*.cpp>
+  +<../mishmesh/vendor/qrcode/*.c>
+  +<../mishmesh/sound/RtttlSource.cpp>
+  +<../mishmesh/sound/ScoreSource.cpp>
+  +<../mishmesh/sound/ToneSequencer.cpp>
+  +<../mishmesh/sound/SoundEngine.cpp>
+  +<../mishmesh/sound/Sounds.cpp>
+  +<../mishmesh/sound/ToneOutput_nrf52.cpp>
+lib_deps = ${GAT562_30S_Mesh_Kit.lib_deps}
+  densaugeo/base64 @ ~1.4.0
+  end2endzone/NonBlockingRTTTL@^1.3.0


### PR DESCRIPTION
## Summary
- Adds `GAT562_30S_Mesh_Kit_companion_radio_usb_mishmesh` / `_ble_mishmesh` envs, porting the standalone mishmesh UI to the GAT562 30S Mesh Kit (nRF52840 + SX1262, SSD1306 display, joystick + buzzer populated per the DIY kit).
- Adds `_nogames` variants of both (drops `Game2048Applet` and the `mishmesh/arduboy` runtime it's the sole consumer of) as a lower-footprint option — saves ~16KB flash / ~1.5KB RAM on this board.
- Adds the `mishmeshBatteryCalFactor` global (used by the UI's battery-calibration screen) to `GAT56230SMeshKitBoard.h`/`.cpp` — it previously only existed for Wio Tracker L1, so linking failed without it.

This board has no external QSPI flash chip (confirmed with a maintainer on Discord — only the GAT562 Watch13 in this product family has one), so it relies on the standard internal LittleFS partition like other non-QSPI boards; nothing board-specific needed there.

## Test plan
- [x] `GAT562_30S_Mesh_Kit_companion_radio_ble_mishmesh` built and **flashed on real GAT562 30S Mesh Kit hardware** (DIY kit variant, with the OLED, joystick, and buzzer populated) — boots and runs mishmesh correctly.
- [x] All four new envs (`usb_mishmesh`, `ble_mishmesh`, `usb_mishmesh_nogames`, `ble_mishmesh_nogames`) build cleanly.
- [x] USB variant and the `_nogames` variants not yet flash-tested on hardware (BLE with-games is the one actually running on my device).